### PR TITLE
Option for renice resource-tracker process and some refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "resource-tracker"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "clap",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resource-tracker"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 description = "Lightweight Linux resource and GPU tracker for system and process monitoring."
 license = "MPL-2.0"
@@ -12,11 +12,11 @@ keywords = ["monitoring", "resources", "gpu", "linux", "metrics"]
 categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
+
 # NVIDIA GPU monitoring via NVML — loaded at runtime with libloading.
 # No build-time system dependencies (no protoc, no libdrm-dev).
 # Gracefully returns an empty Vec on hosts without an NVIDIA GPU/driver.
 nvml-wrapper = "0.12"
-
 
 # CLI argument parsing — stripped to essentials
 clap = { version = "4", default-features = false, features = ["derive", "std", "help", "usage", "error-context", "env"] }
@@ -44,6 +44,7 @@ libc = "0.2"
 
 # Gzip compression for .csv.gz batch uploads to S3
 flate2 = { version = "=1.1.9", default-features = false, features = ["rust_backend"] }
+
 # AMD GPU monitoring via libdrm — loaded at runtime. Required when an AMD GPU
 # is present; gracefully skipped on non-AMD hosts.
 libamdgpu_top = { version = "0.11.2", default-features = false, features = ["libdrm_dynamic_loading"] }

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.1.15] - 2026-08-08
+## [0.1.15] - 2026-08-09
 
 ### Option for renice resource-tracker process
 
@@ -8,11 +8,16 @@ The tracker can now adjust its own priority (`nice` level)
 to ensure maximum CPU resources remain allocated to the traced process.
 The `nice` level is only set after spawning the target process,
 so it doesn't inherit it.
+Note that priority can be increased,
+but it requires `root` privileges.
 
 The option can be set with
 - CLI flag: `-r` or `--renice`,
 - environment variable: `TRACKER_RENICE`,
 - or configuration item: `[tracker]` section, `renice` property.
+
+Even if the OS call fails on a valid `nice` value
+only triggers a warning, the program does not stop.
 
 Under the hood, no external libraries are used -
 the price for that is

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [0.1.15] - 2026-08-08
+
+### Option for renice resource-tracker process
+
+The tracker can now adjust its own priority (`nice` level)
+to ensure maximum CPU resources remain allocated to the traced process.
+The `nice` level is only set after spawning the target process,
+so it doesn't inherit it.
+
+The option can be set with
+- CLI flag: `-r` or `--renice`,
+- environment variable: `TRACKER_RENICE`,
+- or configuration item: `[tracker]` section, `renice` property.
+
+Under the hood, no external libraries are used -
+the price for that is
+a short `unsafe` block for invoking `libc::setpriority()`.
+
+Related ticket: [#28](https://github.com/SpareCores/resource-tracker-rs/issues/28)
+
+### Refactoring of [`main.rs`](src/main.rs)
+
+The main change here is breaking up the long `main()` function
+so the high-level logic is easier to follow.
+
+- Moved tracker states into a struct, which
+- let split the program into smaller methods with minimal parameter passing.
+- Turned the `emit!()` macro into a regular function.
+- Used early `return`-s to reduce indentation level whenever possible.
+
 ## [0.1.14] - 2026-06-09
 
 ### Vultr cloud metadata support

--- a/justfile
+++ b/justfile
@@ -20,10 +20,6 @@ install: build_release
 run_only_show_key_names:
      target/release/resource-tracker --interval 3 | jq -r 'paths(scalars) as $p | "\($p | join(".")): \(getpath($p) | type)"'
 
-launch:
-	clear
-	target/debug/resource-tracker
-
 # Build mdbook and then cargo doc bundled inside, then open the main page
 document:
     (cd resource-tracker-rs-book && mdbook build) & cargo doc --no-deps --offline --target-dir resource-tracker-rs-book/book/cargo/ & wait

--- a/justfile
+++ b/justfile
@@ -1,6 +1,9 @@
 
 set dotenv-load
 
+# honour CARGO_TARGET_DIR if set
+target_dir := env("CARGO_TARGET_DIR", "./target")
+
 help:
     @just --list
 
@@ -10,20 +13,21 @@ format:
 build: format
     cargo build
 
-## (cargo build --release) && upx target/release/resource-tracker
+## (cargo build --release) && upx {{target_dir}}/release/resource-tracker
 build_release:  format
 	cargo build --release
 
 install: build_release
-	(mkdir -p ~/bin) && cp -p ./target/release/resource-tracker ~/bin && echo "resource-tracker is now installed in ~/bin"
+	(mkdir -p ~/bin) && cp -p {{target_dir}}/release/resource-tracker ~/bin && echo "resource-tracker is now installed in ~/bin"
 
 run_only_show_key_names:
-     target/release/resource-tracker --interval 3 | jq -r 'paths(scalars) as $p | "\($p | join(".")): \(getpath($p) | type)"'
+     {{target_dir}}/release/resource-tracker --interval 3 | jq -r 'paths(scalars) as $p | "\($p | join(".")): \(getpath($p) | type)"'
 
 # Build mdbook and then cargo doc bundled inside, then open the main page
 document:
     (cd resource-tracker-rs-book && mdbook build) & cargo doc --no-deps --offline --target-dir resource-tracker-rs-book/book/cargo/ & wait
     xdg-open resource-tracker-rs-book/book/index.html &
+
 
 test:
     env -u SENTINEL_API_TOKEN cargo test -- --test-threads=1
@@ -31,17 +35,14 @@ test:
 test_nocapture:
 	env -u SENTINEL_API_TOKEN cargo test -- --test-threads=1 --nocapture
 
-
-
 real_test1: build_release
-	./target/release/resource-tracker  --format csv
+	{{target_dir}}/release/resource-tracker --format csv
 
 real_test2: build_release
-	./target/release/resource-tracker --format csv Rscript stress.r
-
+	{{target_dir}}/release/resource-tracker --format csv Rscript stress.r
 
 real_test3: build_release
-	./target/release/resource-tracker --format csv Rscript stress.r --cpu 4 --vm 1 --vm-bytes 12024M --timeout 63s
+	{{target_dir}}/release/resource-tracker --format csv Rscript stress.r --cpu 4 --vm 1 --vm-bytes 12024M --timeout 63s
 
 
 report_coverage:
@@ -57,14 +58,12 @@ outdated:
 	@command -v cargo-outdated >/dev/null 2>&1 || cargo install cargo-outdated --locked
 	cargo outdated
 
-
 issue_20_test:
     cargo build --examples
-    ./target/debug/resource-tracker --interval 1 -- ./target/debug/examples/repro_cpu_cutime_spike 2>&1 | grep --line-buffered '^{' | jq '{cores_process: .cpu.process_cores_used, cores_system: .cpu.utilization_pct}'
+    {{target_dir}}/debug/resource-tracker --interval 1 -- {{target_dir}}/debug/examples/repro_cpu_cutime_spike 2>&1 | grep --line-buffered '^{' | jq '{cores_process: .cpu.process_cores_used, cores_system: .cpu.utilization_pct}'
 
 issue_20_test2: build_release
-	TRACKER_QUIET=false sudo ./target/release/resource-tracker -o rt.log nice -n -20 python3 run_stressng_benchmarks.py
-
+	TRACKER_QUIET=false sudo {{target_dir}}/release/resource-tracker -o rt.log nice -n -20 python3 run_stressng_benchmarks.py
 
 
 ## Stub for possisble future use:

--- a/justfile
+++ b/justfile
@@ -20,6 +20,10 @@ install: build_release
 run_only_show_key_names:
      target/release/resource-tracker --interval 3 | jq -r 'paths(scalars) as $p | "\($p | join(".")): \(getpath($p) | type)"'
 
+launch:
+	clear
+	target/debug/resource-tracker
+
 # Build mdbook and then cargo doc bundled inside, then open the main page
 document:
     (cd resource-tracker-rs-book && mdbook build) & cargo doc --no-deps --offline --target-dir resource-tracker-rs-book/book/cargo/ & wait

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use clap::{ArgAction, Parser, ValueEnum};
 use serde::Deserialize;
 
 const DEFAULT_INTERVAL_SECS: u64 = 1;
-const RENICE_MIN: i64 = 0;
+const RENICE_MIN: i64 = -20;
 const RENICE_MAX: i64 = 19;
 const DEFAULT_CONFIG_FILE: &str = "resource-tracker.toml";
 
@@ -96,8 +96,9 @@ struct Cli {
     #[arg(short = 'i', long, value_name = "SECS")]
     interval: Option<u64>,
 
-    /// Nice value for the tracker process: 0 .. 19.
+    /// Nice value for the tracker process: -20 .. 19.
     /// Bare --renice uses the default 19.
+    /// Increasing priority requires root privileges (see: man nice).
     #[arg(
         short = 'r',
         long = "renice",
@@ -106,6 +107,7 @@ struct Cli {
         num_args = 0..=1,
         default_missing_value = "19",
         value_parser = clap::value_parser!(i32).range(RENICE_MIN..=RENICE_MAX),
+        verbatim_doc_comment,
     )]
     renice: Option<i32>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,7 +86,6 @@ pub struct JobMetadata {
     version
 )]
 struct Cli {
-
     // -- Core flags ----------------------------------------------------------
     /// Root PID of the process tree to track CPU usage for.
     /// Overridden automatically in shell-wrapper mode.
@@ -195,7 +194,6 @@ struct Cli {
 /// Resolved configuration after merging CLI args > TOML file > defaults.
 #[derive(Debug, Clone)]
 pub struct Config {
-
     /// Root PID for per-process CPU attribution. None = system-wide only.
     /// Set automatically from the spawned child PID in shell-wrapper mode.
     pub pid: Option<i32>,
@@ -217,11 +215,9 @@ pub struct Config {
 }
 
 impl Config {
-
     /// Parse CLI args, optionally load the TOML config file, and merge with
     /// defaults.  CLI flags always win; config file wins over defaults.
     pub fn load() -> Self {
-
         let cli = Cli::parse();
 
         // Silently skip missing or unparseable config files.

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,12 +2,14 @@ use clap::{ArgAction, Parser, ValueEnum};
 use serde::Deserialize;
 
 const DEFAULT_INTERVAL_SECS: u64 = 1;
+const RENICE_MIN: i64 = 0;
+const RENICE_MAX: i64 = 19;
 const DEFAULT_CONFIG_FILE: &str = "resource-tracker.toml";
 
 // ---------------------------------------------------------------------------
 // Output format
 // ---------------------------------------------------------------------------
-
+//
 /// Output format emitted to stdout on each polling interval.
 #[derive(Debug, Clone, Copy, PartialEq, ValueEnum)]
 pub enum OutputFormat {
@@ -21,7 +23,7 @@ pub enum OutputFormat {
 // ---------------------------------------------------------------------------
 // TOML file structure
 // ---------------------------------------------------------------------------
-
+//
 #[derive(Debug, Default, Deserialize)]
 struct TomlConfig {
     job: Option<TomlJob>,
@@ -40,12 +42,14 @@ struct TomlJob {
 struct TomlTracker {
     /// How often to emit a sample, in seconds. Default: 1.
     interval_secs: Option<u64>,
+    /// Resource tracker nice value. Default: no change.
+    renice: Option<i32>,
 }
 
 // ---------------------------------------------------------------------------
 // Job metadata (Section 9.3) - sent to Sentinel API at run registration
 // ---------------------------------------------------------------------------
-
+//
 /// All optional metadata fields from Section 9.3 of the spec.
 /// Accepted via CLI flags and TRACKER_* environment variables.
 /// Used when registering a run with the Sentinel API (Priority 4).
@@ -72,7 +76,7 @@ pub struct JobMetadata {
 // ---------------------------------------------------------------------------
 // CLI arguments (clap derive)
 // ---------------------------------------------------------------------------
-
+//
 #[derive(Debug, Parser)]
 #[command(
     name = "resource-tracker",
@@ -82,6 +86,7 @@ pub struct JobMetadata {
     version
 )]
 struct Cli {
+
     // -- Core flags ----------------------------------------------------------
     /// Root PID of the process tree to track CPU usage for.
     /// Overridden automatically in shell-wrapper mode.
@@ -91,6 +96,19 @@ struct Cli {
     /// Polling interval in seconds (must be >= 1).
     #[arg(short = 'i', long, value_name = "SECS")]
     interval: Option<u64>,
+
+    /// Nice value for the tracker process: 0 .. 19.
+    /// Bare --renice uses the default 19.
+    #[arg(
+        short = 'r',
+        long = "renice",
+        value_name = "VALUE",
+        env = "TRACKER_RENICE",
+        num_args = 0..=1,
+        default_missing_value = "19",
+        value_parser = clap::value_parser!(i32).range(RENICE_MIN..=RENICE_MAX),
+    )]
+    renice: Option<i32>,
 
     /// Path to TOML config file.
     #[arg(short = 'c', long, value_name = "FILE", default_value = DEFAULT_CONFIG_FILE)]
@@ -173,15 +191,18 @@ struct Cli {
 // ---------------------------------------------------------------------------
 // Merged config
 // ---------------------------------------------------------------------------
-
+//
 /// Resolved configuration after merging CLI args > TOML file > defaults.
 #[derive(Debug, Clone)]
 pub struct Config {
+
     /// Root PID for per-process CPU attribution. None = system-wide only.
     /// Set automatically from the spawned child PID in shell-wrapper mode.
     pub pid: Option<i32>,
     /// Polling interval in seconds.
     pub interval_secs: u64,
+    /// Nice value applied to the tracker process itself (0..=19).
+    pub renice: Option<i32>,
     /// Output format (JSON or CSV).
     pub format: OutputFormat,
     /// Write metric output to this file path instead of stdout.
@@ -196,9 +217,11 @@ pub struct Config {
 }
 
 impl Config {
+
     /// Parse CLI args, optionally load the TOML config file, and merge with
     /// defaults.  CLI flags always win; config file wins over defaults.
     pub fn load() -> Self {
+
         let cli = Cli::parse();
 
         // Silently skip missing or unparseable config files.
@@ -216,6 +239,10 @@ impl Config {
             eprintln!("error: --interval must be >= 1 (got 0)");
             std::process::exit(1);
         }
+
+        let renice = cli
+            .renice
+            .or_else(|| toml.tracker.as_ref().and_then(|t| t.renice));
 
         let pid = cli.pid.or_else(|| toml.job.as_ref().and_then(|j| j.pid));
 
@@ -240,6 +267,7 @@ impl Config {
         Config {
             pid,
             interval_secs,
+            renice,
             format: cli.format,
             output_file: cli.output,
             quiet: cli.quiet,

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,6 +237,20 @@ impl ResourceTracker {
         }
     }
 
+    fn renice_self(&self) {
+
+        let Some(renice) = self.config.renice else {
+            return;
+        };
+
+        let result = unsafe {
+            libc::setpriority(libc::PRIO_PROCESS, 0, renice)
+        };
+        if result == -1 {
+            eprintln!("warn: failed to renice process, ignored");
+        }
+    }
+
     fn poll_cloud_info(&mut self) {
 
         if self.cloud_info.is_none()

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,31 +15,19 @@ mod thread_util;
 
 extern crate libc;
 
-use std::io::{Write, BufWriter};
-use std::fs::File;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use collector::{
-    CpuCollector,
-    DiskCollector,
-    GpuCollector,
-    MemoryCollector,
-    NetworkCollector,
-    collect_host_info,
-    spawn_cloud_discovery,
+    CpuCollector, DiskCollector, GpuCollector, MemoryCollector, NetworkCollector,
+    collect_host_info, spawn_cloud_discovery,
 };
 use config::{Config, OutputFormat};
 use metrics::CloudInfo;
 use metrics::Sample;
-use sentinel::{
-    BatchUploader,
-    RunContext,
-    SentinelClient,
-    close_run,
-    samples_to_csv,
-    start_run,
-};
+use sentinel::{BatchUploader, RunContext, SentinelClient, close_run, samples_to_csv, start_run};
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 // ---------------------------------------------------------------------------
 // SIGTERM handler
@@ -55,7 +43,6 @@ extern "C" fn handle_sigterm(_: libc::c_int) {
 // Both signals set the same flag and trigger the same graceful shutdown path.
 //
 fn setup_signal_handlers() {
-
     unsafe {
         libc::signal(
             libc::SIGTERM,
@@ -69,7 +56,6 @@ fn setup_signal_handlers() {
 }
 
 struct ResourceTracker {
-
     config: Config,
     out_file: Option<std::io::BufWriter<std::fs::File>>,
     interval: Duration,
@@ -102,9 +88,7 @@ struct ResourceTracker {
 }
 
 impl ResourceTracker {
-
     fn new() -> Self {
-
         let config = Config::load();
         let out_file = Self::create_sink(&config);
         let interval = Duration::from_secs(config.interval_secs);
@@ -149,20 +133,17 @@ impl ResourceTracker {
     }
 
     fn warmup_collectors(&mut self) {
-
         let _ = self.cpu.collect();
         let _ = self.network.collect();
         let _ = self.disk.collect();
     }
 
     fn spawn_tracked_command(&mut self) {
-
         let Some((program, args)) = self.config.command.split_first() else {
             return;
         };
 
         match std::process::Command::new(program).args(args).spawn() {
-
             Ok(c) => {
                 self.config.pid = Some(i32::try_from(c.id()).unwrap_or(i32::MAX));
                 self.cpu.set_tracked_pid(self.config.pid);
@@ -177,7 +158,6 @@ impl ResourceTracker {
     }
 
     fn setup_sentinel(&mut self) {
-
         self.sentinel = SentinelClient::from_env();
 
         let Some(client) = &self.sentinel else {
@@ -234,28 +214,23 @@ impl ResourceTracker {
     }
 
     fn emit_csv_header(&mut self) {
-
         if self.config.format == OutputFormat::Csv {
             Self::emit_metric_line(&self.config, &mut self.out_file, output::csv::csv_header());
         }
     }
 
     fn renice_tracker(&self) {
-
         let Some(renice) = self.config.renice else {
             return;
         };
 
-        let result = unsafe {
-            libc::setpriority(libc::PRIO_PROCESS, 0, renice)
-        };
+        let result = unsafe { libc::setpriority(libc::PRIO_PROCESS, 0, renice) };
         if result == -1 {
             eprintln!("warn: failed to renice process, ignored");
         }
     }
 
     fn poll_cloud_info(&mut self) {
-
         if self.cloud_info.is_none()
             && let Some(ref rx) = self.cloud_rx
             && let Ok(info) = rx.try_recv()
@@ -265,10 +240,10 @@ impl ResourceTracker {
     }
 
     fn collect_sample(&mut self) -> Sample {
-
         let loop_start = Instant::now();
 
-        let actual_interval_ms: Option<u64> = self.prev_loop_start
+        let actual_interval_ms: Option<u64> = self
+            .prev_loop_start
             .map(|p| u64::try_from((loop_start - p).as_millis()).unwrap_or(u64::MAX));
 
         let timestamp_secs = SystemTime::now()
@@ -311,18 +286,12 @@ impl ResourceTracker {
     }
 
     fn emit_sample(&mut self, sample: &Sample) {
-
         match self.config.format {
-
             OutputFormat::Json => match serde_json::to_value(sample) {
                 Ok(mut v) => {
                     v[format!("{}-version", env!("CARGO_PKG_NAME"))] =
                         serde_json::Value::String(env!("CARGO_PKG_VERSION").to_string());
-                    Self::emit_metric_line(
-                        &self.config,
-                        &mut self.out_file,
-                        &v.to_string(),
-                    );
+                    Self::emit_metric_line(&self.config, &mut self.out_file, &v.to_string());
                 }
                 Err(e) => eprintln!("warn: json serialize error: {e}"),
             },
@@ -338,7 +307,6 @@ impl ResourceTracker {
     }
 
     fn buffer_sample(&mut self, sample: Sample) {
-
         // Push to sentinel buffer (if streaming is active).
         if let Some(ref buf) = self.sample_buffer {
             buf.lock()
@@ -349,7 +317,6 @@ impl ResourceTracker {
     }
 
     fn check_child_exit(&mut self) -> Option<i32> {
-
         let child = self.child.as_mut()?;
 
         match child.try_wait() {
@@ -367,7 +334,6 @@ impl ResourceTracker {
     }
 
     fn sleep_until_next_interval(&self, loop_start: Instant) {
-
         let elapsed = loop_start.elapsed();
         if let Some(remaining) = self.interval.checked_sub(elapsed) {
             std::thread::sleep(remaining);
@@ -375,7 +341,6 @@ impl ResourceTracker {
     }
 
     fn shutdown(&mut self, exit_code: i32) -> ! {
-
         // Take ownership of fields that need to be moved
         let sentinel = self.sentinel.take();
         let run_ctx = self.run_ctx_arc.take();
@@ -395,7 +360,6 @@ impl ResourceTracker {
     }
 
     fn run(mut self) -> ! {
-
         self.warmup_collectors();
         std::thread::sleep(self.interval);
 
@@ -424,14 +388,12 @@ impl ResourceTracker {
         }
     }
 
-
     // -----------------------------------------------------------------------
     // Output sink: stdout (default), file (--output), or suppressed (--quiet).
     // Warnings and errors always go to stderr via eprintln! regardless.
     // -----------------------------------------------------------------------
     //
     fn create_sink(config: &Config) -> Option<BufWriter<File>> {
-
         if config.quiet {
             return None;
         }
@@ -461,7 +423,6 @@ impl ResourceTracker {
         remaining: Vec<Sample>,
         interval_secs: u64,
     ) -> ! {
-
         if let (Some(client), Some(ctx_arc), Some(flag), Some(handle)) =
             (sentinel, run_ctx, shutdown_flag, upload_handle)
         {
@@ -505,7 +466,6 @@ impl ResourceTracker {
     // default     -> eprintln! to stderr (keeps stdout clean for the tracked app)
     //
     fn emit_metric_line(config: &Config, out_file: &mut Option<BufWriter<File>>, msg: &str) {
-
         if config.quiet {
             return;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,23 +14,34 @@ mod thread_util;
 
 extern crate libc;
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use collector::{
-    CpuCollector, DiskCollector, GpuCollector, MemoryCollector, NetworkCollector,
-    collect_host_info, spawn_cloud_discovery,
+    CpuCollector,
+    DiskCollector,
+    GpuCollector,
+    MemoryCollector,
+    NetworkCollector,
+    collect_host_info,
+    spawn_cloud_discovery,
 };
 use config::{Config, OutputFormat};
 use metrics::CloudInfo;
 use metrics::Sample;
-use sentinel::{BatchUploader, RunContext, SentinelClient, close_run, samples_to_csv, start_run};
-use std::io::Write;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use sentinel::{
+    BatchUploader,
+    RunContext,
+    SentinelClient,
+    close_run,
+    samples_to_csv,
+    start_run,
+};
 
 // ---------------------------------------------------------------------------
 // SIGTERM handler
 // ---------------------------------------------------------------------------
-
+//
 static SIGTERM_RECEIVED: AtomicBool = AtomicBool::new(false);
 
 extern "C" fn handle_sigterm(_: libc::c_int) {
@@ -41,6 +52,7 @@ extern "C" fn handle_sigterm(_: libc::c_int) {
 // Both signals set the same flag and trigger the same graceful shutdown path.
 //
 fn setup_signal_handlers() {
+
     unsafe {
         libc::signal(
             libc::SIGTERM,
@@ -53,24 +65,362 @@ fn setup_signal_handlers() {
     }
 }
 
+struct ResourceTracker {
+
+    config: Config,
+    out_file: Option<std::io::BufWriter<std::fs::File>>,
+    interval: Duration,
+
+    // Collectors
+    cpu: CpuCollector,
+    memory: MemoryCollector,
+    network: NetworkCollector,
+    disk: DiskCollector,
+    gpu: GpuCollector,
+
+    // Cloud and host info
+    host_info: metrics::HostInfo,
+    cloud_info: Option<CloudInfo>,
+    cloud_rx: Option<std::sync::mpsc::Receiver<CloudInfo>>,
+
+    // Child process
+    child: Option<std::process::Child>,
+
+    // Sentinel state
+    sentinel: Option<SentinelClient>,
+    run_ctx_arc: Option<Arc<Mutex<RunContext>>>,
+    sample_buffer: Option<Arc<Mutex<Vec<Sample>>>>,
+    upload_shutdown_flag: Option<Arc<AtomicBool>>,
+    upload_handle: Option<std::thread::JoinHandle<Vec<String>>>,
+
+    // Sample tracking
+    unflushed: Vec<Sample>,
+    prev_loop_start: Option<Instant>,
+}
+
+impl ResourceTracker {
+
+    fn new() -> Self {
+
+        let config = Config::load();
+        let out_file = create_sink(&config);
+        let interval = Duration::from_secs(config.interval_secs);
+
+        let cpu = CpuCollector::new(config.pid);
+        let memory = MemoryCollector::new();
+        let network = NetworkCollector::new();
+        let disk = DiskCollector::new(interval);
+        let gpu = GpuCollector::new();
+
+        // Collect static GPU info now so host discovery can derive GPU host fields.
+        let initial_gpus = gpu.collect().unwrap_or_default();
+
+        // Host discovery: fast, local, no I/O.
+        let host_info = collect_host_info(&initial_gpus);
+
+        // Warm-up: prime delta state in stateful collectors while cloud probes run
+        let cloud_rx = spawn_cloud_discovery();
+        let cloud_info = None;
+
+        Self {
+            config,
+            out_file,
+            interval,
+            cpu,
+            memory,
+            network,
+            disk,
+            gpu,
+            host_info,
+            cloud_info,
+            cloud_rx,
+            child: None,
+            sentinel: None,
+            run_ctx_arc: None,
+            sample_buffer: None,
+            upload_shutdown_flag: None,
+            upload_handle: None,
+            unflushed: Vec::new(),
+            prev_loop_start: None,
+        }
+    }
+
+    fn warmup_collectors(&mut self) {
+
+        let _ = self.cpu.collect();
+        let _ = self.network.collect();
+        let _ = self.disk.collect();
+    }
+
+    fn spawn_tracked_command(&mut self) {
+
+        let Some((program, args)) = self.config.command.split_first() else {
+            return;
+        };
+
+        match std::process::Command::new(program).args(args).spawn() {
+
+            Ok(c) => {
+                self.config.pid = Some(i32::try_from(c.id()).unwrap_or(i32::MAX));
+                self.cpu.set_tracked_pid(self.config.pid);
+                self.child = Some(c);
+            }
+
+            Err(e) => {
+                eprintln!("error: failed to spawn {:?}: {e}", program);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    fn setup_sentinel(&mut self) {
+
+        self.sentinel = SentinelClient::from_env();
+
+        let Some(client) = &self.sentinel else {
+            return;
+        };
+
+        // Bounded wait: give cloud discovery a chance to complete
+        if self.cloud_info.is_none() {
+            if let Some(ref rx) = self.cloud_rx {
+                self.cloud_info = rx.recv_timeout(Duration::from_secs(3)).ok();
+            }
+        }
+
+        let default_cloud = CloudInfo::default();
+        let ctx = match start_run(
+            &client.agent,
+            &client.api_base,
+            &client.token,
+            &self.config.metadata,
+            self.config.pid,
+            &self.host_info,
+            self.cloud_info.as_ref().unwrap_or(&default_cloud),
+        ) {
+            Err(e) => {
+                eprintln!("warn: sentinel start_run failed: {e}; streaming disabled");
+                return;
+            }
+            Ok(ctx) => ctx,
+        };
+
+        let ctx_arc = Arc::new(Mutex::new(ctx));
+        let upload_interval = std::env::var("TRACKER_UPLOAD_INTERVAL")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(60u64);
+        let (uploader, buf) = BatchUploader::new(upload_interval, self.config.interval_secs);
+        let flag = uploader.shutdown_flag();
+        let upload_handle = uploader.spawn(
+            Arc::clone(&ctx_arc),
+            SentinelClient::new_upload_agent(),
+            client.api_base.clone(),
+            client.token.clone(),
+        );
+        if upload_handle.is_none() {
+            eprintln!(
+                "warn: sentinel background upload disabled; samples will be flushed inline on exit"
+            );
+        }
+
+        self.run_ctx_arc = Some(ctx_arc);
+        self.sample_buffer = Some(buf);
+        self.upload_shutdown_flag = Some(flag);
+        self.upload_handle = upload_handle;
+    }
+
+    fn emit_csv_header(&mut self) {
+
+        if self.config.format == OutputFormat::Csv {
+            emit_metric_line(&self.config, &mut self.out_file, output::csv::csv_header());
+        }
+    }
+
+    fn poll_cloud_info(&mut self) {
+
+        if self.cloud_info.is_none()
+            && let Some(ref rx) = self.cloud_rx
+            && let Ok(info) = rx.try_recv()
+        {
+            self.cloud_info = Some(info);
+        }
+    }
+
+    fn collect_sample(&mut self) -> Sample {
+
+        let loop_start = Instant::now();
+
+        let actual_interval_ms: Option<u64> = self.prev_loop_start
+            .map(|p| u64::try_from((loop_start - p).as_millis()).unwrap_or(u64::MAX));
+
+        let timestamp_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let mut sample = Sample {
+            timestamp_secs,
+            actual_interval_ms,
+            job_name: self.config.metadata.job_name.clone(),
+            tracked_pid: self.config.pid,
+            cpu: self.cpu.collect().unwrap_or_default(),
+            memory: self.memory.collect().unwrap_or_default(),
+            network: self.network.collect().unwrap_or_default(),
+            disk: self.disk.collect().unwrap_or_default(),
+            gpu: self.gpu.collect().unwrap_or_default(),
+        };
+
+        // Augment with per-process GPU stats.
+        let (vram_mib, gpu_usage, gpu_utilized) =
+            if self.config.pid.is_some() && !sample.cpu.process_tree_pids.is_empty() {
+                let pids_u32: Vec<u32> = sample
+                    .cpu
+                    .process_tree_pids
+                    .iter()
+                    .filter_map(|&p| u32::try_from(p).ok())
+                    .collect();
+                self.gpu.process_gpu_info(&pids_u32, self.interval)
+            } else {
+                self.gpu.all_gpu_process_info(self.interval)
+            };
+        sample.cpu.process_gpu_vram_mib = vram_mib;
+        sample.cpu.process_gpu_usage = gpu_usage;
+        sample.cpu.process_gpu_utilized = gpu_utilized;
+
+        self.prev_loop_start = Some(loop_start);
+        sample
+    }
+
+    fn emit_sample(&mut self, sample: &Sample) {
+
+        match self.config.format {
+
+            OutputFormat::Json => match serde_json::to_value(sample) {
+                Ok(mut v) => {
+                    v[format!("{}-version", env!("CARGO_PKG_NAME"))] =
+                        serde_json::Value::String(env!("CARGO_PKG_VERSION").to_string());
+                    emit_metric_line(
+                        &self.config,
+                        &mut self.out_file,
+                        &v.to_string(),
+                    );
+                }
+                Err(e) => eprintln!("warn: json serialize error: {e}"),
+            },
+
+            OutputFormat::Csv => {
+                emit_metric_line(
+                    &self.config,
+                    &mut self.out_file,
+                    &output::csv::sample_to_csv_row(sample, self.config.interval_secs),
+                );
+            }
+        }
+    }
+
+    fn buffer_sample(&mut self, sample: Sample) {
+
+        // Push to sentinel buffer (if streaming is active).
+        if let Some(ref buf) = self.sample_buffer {
+            buf.lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(sample.clone());
+        }
+        self.unflushed.push(sample);
+    }
+
+    fn check_child_exit(&mut self) -> Option<i32> {
+
+        let child = self.child.as_mut()?;
+
+        match child.try_wait() {
+            Ok(Some(status)) => Some(status.code().unwrap_or(1)),
+            Ok(None) => None,
+            Err(e) => {
+                eprintln!("warn: error checking child status: {e}");
+                None
+            }
+        }
+    }
+
+    fn check_signal(&self) -> bool {
+        SIGTERM_RECEIVED.load(Ordering::Relaxed)
+    }
+
+    fn sleep_until_next_interval(&self, loop_start: Instant) {
+
+        let elapsed = loop_start.elapsed();
+        if let Some(remaining) = self.interval.checked_sub(elapsed) {
+            std::thread::sleep(remaining);
+        }
+    }
+
+    fn shutdown(&mut self, exit_code: i32) -> ! {
+
+        // Take ownership of fields that need to be moved
+        let sentinel = self.sentinel.take();
+        let run_ctx = self.run_ctx_arc.take();
+        let shutdown_flag = self.upload_shutdown_flag.take();
+        let upload_handle = self.upload_handle.take();
+        let remaining = std::mem::take(&mut self.unflushed);
+
+        shutdown(
+            exit_code,
+            sentinel.as_ref(),
+            run_ctx,
+            shutdown_flag,
+            upload_handle,
+            remaining,
+            self.config.interval_secs,
+        );
+    }
+
+    fn run(mut self) -> ! {
+
+        self.warmup_collectors();
+        std::thread::sleep(self.interval);
+        self.spawn_tracked_command();
+        self.setup_sentinel();
+        self.emit_csv_header();
+
+        // Main sampling loop
+        loop {
+            self.poll_cloud_info();
+            let loop_start = Instant::now();
+
+            let sample = self.collect_sample();
+            self.emit_sample(&sample);
+            self.buffer_sample(sample);
+
+            if let Some(code) = self.check_child_exit() {
+                self.shutdown(code);
+            }
+
+            if self.check_signal() {
+                self.shutdown(0);
+            }
+
+            self.sleep_until_next_interval(loop_start);
+        }
+    }
+}
+
 // -----------------------------------------------------------------------
 // Output sink: stdout (default), file (--output), or suppressed (--quiet).
 // Warnings and errors always go to stderr via eprintln! regardless.
 // -----------------------------------------------------------------------
 //
-fn create_sink(config: &Config) -> Option<std::io::BufWriter<std::fs::File>> {
-    let out_file = if config.quiet {
-        None
-    } else {
-        config.output_file.as_deref().map(|path| {
-            std::io::BufWriter::new(std::fs::File::create(path).unwrap_or_else(|e| {
-                eprintln!("error: cannot open output file {path}: {e}");
-                std::process::exit(1);
-            }))
-        })
-    };
+fn create_sink(config: &Config) -> Option<BufWriter<File>> {
 
-    out_file
+    if config.quiet {
+        return None;
+    }
+
+    match config.output_file.as_deref() {
+        Some(path) => File::create(path).map(BufWriter::new).ok(),
+        None => None,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -92,6 +442,7 @@ fn shutdown(
     remaining: Vec<Sample>,
     interval_secs: u64,
 ) -> ! {
+
     if let (Some(client), Some(ctx_arc), Some(flag), Some(handle)) =
         (sentinel, run_ctx, shutdown_flag, upload_handle)
     {
@@ -126,7 +477,7 @@ fn shutdown(
         }
     }
 
-    std::process::exit(exit_code)
+    std::process::exit(exit_code);
 }
 
 // Emit one line of metric output to the selected sink.
@@ -134,282 +485,31 @@ fn shutdown(
 // output_file -> write to file and flush (so `tail -f` works)
 // default     -> eprintln! to stderr (keeps stdout clean for the tracked app)
 //
-fn emit(config: &Config, out_file: &mut Option<std::io::BufWriter<std::fs::File>>, msg: &str) {
-    if !config.quiet {
-        if let Some(f) = out_file {
-            let _ = writeln!(f, "{}", msg);
-            let _ = f.flush();
-        } else {
-            eprintln!("{}", msg);
+use std::io::{Write, BufWriter};
+use std::fs::File;
+
+fn emit_metric_line(config: &Config, out_file: &mut Option<BufWriter<File>>, msg: &str) {
+
+    if config.quiet {
+        return;
+    }
+
+    match out_file {
+        Some(writer) => {
+            let _ = writeln!(writer, "{msg}");
+            let _ = writer.flush();
         }
+        None => eprintln!("{msg}"),
     }
 }
-
 // ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
 //
 fn main() {
     setup_signal_handlers();
-    let mut config = Config::load();
-    let mut out_file = create_sink(&config);
-
-    let interval = Duration::from_secs(config.interval_secs);
-
-    let mut cpu = CpuCollector::new(config.pid);
-    let memory = MemoryCollector::new();
-    let mut network = NetworkCollector::new();
-    let mut disk = DiskCollector::new(interval);
-    let mut gpu = GpuCollector::new();
-
-    // Collect static GPU info now so host discovery can derive GPU host fields.
-    let initial_gpus = gpu.collect().unwrap_or_default();
-
-    // Host discovery: fast, local, no I/O.
-    let host_info = collect_host_info(&initial_gpus);
-
-    // Warm-up: prime delta state in stateful collectors while cloud probes run
-    // in the background. spawn_cloud_discovery returns a channel Receiver so
-    // the caller never blocks on probe completion -- try_recv() picks up the
-    // result if probes finished during the sleep, or leaves cloud_info as None
-    // to be resolved later (per-tick poll in the main loop, or recv_timeout
-    // before start_run for Sentinel runs).
-    let cloud_rx = spawn_cloud_discovery();
-    let _ = cpu.collect();
-    let _ = network.collect();
-    let _ = disk.collect();
-
-    std::thread::sleep(interval);
-
-    // Non-blocking: on most non-cloud machines all probes fail fast
-    // (EHOSTUNREACH); on cloud machines the matching probe returns in < 100 ms.
-    // Either way the result is typically waiting by the time we reach here.
-    let mut cloud_info: Option<CloudInfo> = cloud_rx.as_ref().and_then(|rx| rx.try_recv().ok());
-
-    // Shell-wrapper child is spawned after warm-up so cloud IMDS probes (ureq may
-    // use helper threads) do not race with fork-heavy stressors under PID limits.
-    let mut child: Option<std::process::Child> = None;
-
-    // -----------------------------------------------------------------------
-    // Shell-wrapper mode: spawn the tracked command after warm-up / cloud probe.
-    // -----------------------------------------------------------------------
-    if !config.command.is_empty() {
-        let (program, args) = config.command.split_first().expect("command is non-empty");
-        match std::process::Command::new(program).args(args).spawn() {
-            Ok(c) => {
-                config.pid = Some(i32::try_from(c.id()).unwrap_or(i32::MAX));
-                cpu.set_tracked_pid(config.pid);
-                child = Some(c);
-            }
-            Err(e) => {
-                eprintln!("error: failed to spawn {:?}: {e}", program);
-                std::process::exit(1);
-            }
-        }
-    }
-
-    // -----------------------------------------------------------------------
-    // Sentinel API setup (gated on SENTINEL_API_TOKEN being set).
-    // -----------------------------------------------------------------------
-    let sentinel = SentinelClient::from_env();
-
-    let (run_ctx_arc, sample_buffer, upload_shutdown_flag, upload_handle) = match &sentinel {
-        None => (None, None, None, None),
-        Some(client) => {
-            // Bounded wait: give cloud discovery a chance to complete before
-            // start_run so the run record carries cloud metadata. IMDS probes
-            // run in parallel and finish within IMDS_TIMEOUT (1 s); 3 s is a
-            // generous ceiling for unusual network paths. Pure metric runs
-            // (no Sentinel token) skip this entirely.
-            if cloud_info.is_none() {
-                if let Some(ref rx) = cloud_rx {
-                    cloud_info = rx.recv_timeout(Duration::from_secs(3)).ok();
-                }
-            }
-            let default_cloud = CloudInfo::default();
-            match start_run(
-                &client.agent,
-                &client.api_base,
-                &client.token,
-                &config.metadata,
-                config.pid,
-                &host_info,
-                cloud_info.as_ref().unwrap_or(&default_cloud),
-            ) {
-                Err(e) => {
-                    eprintln!("warn: sentinel start_run failed: {e}; streaming disabled");
-                    (None, None, None, None)
-                }
-                Ok(ctx) => {
-                    let ctx_arc = Arc::new(Mutex::new(ctx));
-                    let upload_interval = std::env::var("TRACKER_UPLOAD_INTERVAL")
-                        .ok()
-                        .and_then(|v| v.parse().ok())
-                        .unwrap_or(60u64);
-                    let (uploader, buf) = BatchUploader::new(upload_interval, config.interval_secs);
-                    let flag = uploader.shutdown_flag();
-                    let upload_handle = uploader.spawn(
-                        Arc::clone(&ctx_arc),
-                        SentinelClient::new_upload_agent(),
-                        client.api_base.clone(),
-                        client.token.clone(),
-                    );
-                    if upload_handle.is_none() {
-                        eprintln!(
-                            "warn: sentinel background upload disabled; samples will be flushed inline on exit"
-                        );
-                    }
-                    (Some(ctx_arc), Some(buf), Some(flag), upload_handle)
-                }
-            }
-        }
-    };
-
-    // Emit CSV header once before the loop.
-    if config.format == OutputFormat::Csv {
-        emit(&config, &mut out_file, output::csv::csv_header());
-    }
-
-    // Samples collected since the last S3 batch upload (for local fallback).
-    let mut unflushed: Vec<Sample> = Vec::new();
-
-    // Tracks the Instant at the start of each loop iteration so we can
-    // compute the actual elapsed interval between samples and sleep only
-    // for the remainder of the nominal interval (deadline-based scheduling).
-    let mut prev_loop_start: Option<Instant> = None;
-
-    // -----------------------------------------------------------------------
-    // Main sampling loop
-    // -----------------------------------------------------------------------
-    loop {
-        // Poll for cloud discovery result if not yet received. Typically a
-        // no-op because probes complete within IMDS_TIMEOUT and the warm-up
-        // sleep covers that window. Ensures the channel is drained and
-        // cloud_info is populated for any future use.
-        if cloud_info.is_none()
-            && let Some(ref rx) = cloud_rx
-            && let Ok(info) = rx.try_recv()
-        {
-            cloud_info = Some(info);
-        }
-
-        let loop_start = Instant::now();
-
-        // Actual elapsed since the previous iteration started.  None on the
-        // first real sample (no prior loop start to compare against).
-        let actual_interval_ms: Option<u64> = prev_loop_start
-            .map(|p| u64::try_from((loop_start - p).as_millis()).unwrap_or(u64::MAX));
-
-        let timestamp_secs = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-
-        let mut sample = Sample {
-            timestamp_secs,
-            actual_interval_ms,
-            job_name: config.metadata.job_name.clone(),
-            tracked_pid: config.pid,
-            cpu: cpu.collect().unwrap_or_default(),
-            memory: memory.collect().unwrap_or_default(),
-            network: network.collect().unwrap_or_default(),
-            disk: disk.collect().unwrap_or_default(),
-            gpu: gpu.collect().unwrap_or_default(),
-        };
-
-        // Augment with per-process GPU stats.
-        // With --pid: filter to the tracked process tree.
-        // Without --pid: report system-wide GPU allocation (all processes).
-        let (vram_mib, gpu_usage, gpu_utilized) =
-            if config.pid.is_some() && !sample.cpu.process_tree_pids.is_empty() {
-                let pids_u32: Vec<u32> = sample
-                    .cpu
-                    .process_tree_pids
-                    .iter()
-                    .filter_map(|&p| u32::try_from(p).ok())
-                    .collect();
-                gpu.process_gpu_info(&pids_u32, interval)
-            } else {
-                gpu.all_gpu_process_info(interval)
-            };
-        sample.cpu.process_gpu_vram_mib = vram_mib;
-        sample.cpu.process_gpu_usage = gpu_usage;
-        sample.cpu.process_gpu_utilized = gpu_utilized;
-
-        // Emit to selected output sink.
-        match config.format {
-            OutputFormat::Json => match serde_json::to_value(&sample) {
-                Ok(mut v) => {
-                    v[format!("{}-version", env!("CARGO_PKG_NAME"))] =
-                        serde_json::Value::String(env!("CARGO_PKG_VERSION").to_string());
-                    emit(&config, &mut out_file, &v.to_string());
-                }
-                Err(e) => eprintln!("warn: json serialize error: {e}"),
-            },
-            OutputFormat::Csv => {
-                emit(
-                    &config,
-                    &mut out_file,
-                    &output::csv::sample_to_csv_row(&sample, config.interval_secs),
-                );
-            }
-        }
-
-        // Push to sentinel buffer (if streaming is active).
-        if let Some(ref buf) = sample_buffer {
-            buf.lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .push(sample.clone());
-        }
-        unflushed.push(sample);
-
-        // -----------------------------------------------------------------------
-        // Shell-wrapper exit check
-        // -----------------------------------------------------------------------
-        if let Some(ref mut c) = child {
-            match c.try_wait() {
-                Ok(Some(status)) => {
-                    let code = status.code().unwrap_or(1);
-                    shutdown(
-                        code,
-                        sentinel.as_ref(),
-                        run_ctx_arc,
-                        upload_shutdown_flag,
-                        upload_handle,
-                        unflushed,
-                        config.interval_secs,
-                    );
-                }
-                Ok(None) => {}
-                Err(e) => eprintln!("warn: error checking child status: {e}"),
-            }
-        }
-
-        // SIGTERM received: flush and exit cleanly.
-        if SIGTERM_RECEIVED.load(Ordering::Relaxed) {
-            shutdown(
-                0,
-                sentinel.as_ref(),
-                run_ctx_arc,
-                upload_shutdown_flag,
-                upload_handle,
-                unflushed,
-                config.interval_secs,
-            );
-        }
-
-        prev_loop_start = Some(loop_start);
-
-        // Deadline-based sleep: sleep only for the time remaining in the
-        // nominal interval.  If collection itself took longer than the
-        // interval, skip sleeping entirely and start the next sample right
-        // away.  This prevents drift accumulation and matches the Python
-        // resource-tracker's timer approach.
-        let elapsed = loop_start.elapsed();
-        if let Some(remaining) = interval.checked_sub(elapsed) {
-            std::thread::sleep(remaining);
-        }
-    }
+    let tracker = ResourceTracker::new();
+    tracker.run();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -383,6 +383,7 @@ impl ResourceTracker {
         self.spawn_tracked_command();
         self.setup_sentinel();
         self.emit_csv_header();
+        self.renice_self();
 
         // Main sampling loop
         loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,15 +37,52 @@ extern "C" fn handle_sigterm(_: libc::c_int) {
     SIGTERM_RECEIVED.store(true, Ordering::Relaxed);
 }
 
+// Install SIGTERM and SIGINT handlers so the binary can flush before exiting.
+// Both signals set the same flag and trigger the same graceful shutdown path.
+//
+fn setup_signal_handlers() {
+    unsafe {
+        libc::signal(
+            libc::SIGTERM,
+            handle_sigterm as *const () as libc::sighandler_t,
+        );
+        libc::signal(
+            libc::SIGINT,
+            handle_sigterm as *const () as libc::sighandler_t,
+        );
+    }
+}
+
+// -----------------------------------------------------------------------
+// Output sink: stdout (default), file (--output), or suppressed (--quiet).
+// Warnings and errors always go to stderr via eprintln! regardless.
+// -----------------------------------------------------------------------
+//
+fn create_sink(config: &Config) -> Option<std::io::BufWriter<std::fs::File>> {
+    let out_file = if config.quiet {
+        None
+    } else {
+        config.output_file.as_deref().map(|path| {
+            std::io::BufWriter::new(std::fs::File::create(path).unwrap_or_else(|e| {
+                eprintln!("error: cannot open output file {path}: {e}");
+                std::process::exit(1);
+            }))
+        })
+    };
+
+    out_file
+}
+
 // ---------------------------------------------------------------------------
 // Graceful shutdown
 // ---------------------------------------------------------------------------
-
-/// Flush remaining samples, close the Sentinel run, then exit.
-///
-/// Called on both shell-wrapper child exit and SIGTERM.  Replaces the former
-/// bare `std::process::exit()` calls so the upload thread always gets a chance
-/// to flush.
+//
+// Flush remaining samples, close the Sentinel run, then exit.
+//
+// Called on both shell-wrapper child exit and SIGTERM.  Replaces the former
+// bare `std::process::exit()` calls so the upload thread always gets a chance
+// to flush.
+//
 fn shutdown(
     exit_code: i32,
     sentinel: Option<&SentinelClient>,
@@ -89,66 +126,35 @@ fn shutdown(
         }
     }
 
-    std::process::exit(exit_code);
+    std::process::exit(exit_code)
+}
+
+// Emit one line of metric output to the selected sink.
+// quiet=true  -> no-op
+// output_file -> write to file and flush (so `tail -f` works)
+// default     -> eprintln! to stderr (keeps stdout clean for the tracked app)
+//
+fn emit(config: &Config, out_file: &mut Option<std::io::BufWriter<std::fs::File>>, msg: &str) {
+    if !config.quiet {
+        if let Some(f) = out_file {
+            let _ = writeln!(f, "{}", msg);
+            let _ = f.flush();
+        } else {
+            eprintln!("{}", msg);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
-
+//
 fn main() {
-    // Install SIGTERM and SIGINT handlers so the binary can flush before exiting.
-    // Both signals set the same flag and trigger the same graceful shutdown path.
-    unsafe {
-        libc::signal(
-            libc::SIGTERM,
-            handle_sigterm as *const () as libc::sighandler_t,
-        );
-        libc::signal(
-            libc::SIGINT,
-            handle_sigterm as *const () as libc::sighandler_t,
-        );
-    }
-
+    setup_signal_handlers();
     let mut config = Config::load();
-
-    // -----------------------------------------------------------------------
-    // Output sink: stdout (default), file (--output), or suppressed (--quiet).
-    // Warnings and errors always go to stderr via eprintln! regardless.
-    // -----------------------------------------------------------------------
-    let mut out_file: Option<std::io::BufWriter<std::fs::File>> = if config.quiet {
-        None
-    } else {
-        config.output_file.as_deref().map(|path| {
-            std::io::BufWriter::new(std::fs::File::create(path).unwrap_or_else(|e| {
-                eprintln!("error: cannot open output file {path}: {e}");
-                std::process::exit(1);
-            }))
-        })
-    };
-
-    // Emit one line of metric output to the selected sink.
-    // quiet=true  -> no-op
-    // output_file -> write to file and flush (so `tail -f` works)
-    // default     -> eprintln! to stderr (keeps stdout clean for the tracked app)
-    macro_rules! emit {
-        ($($arg:tt)*) => {
-            if !config.quiet {
-                if let Some(ref mut f) = out_file {
-                    let _ = writeln!(f, $($arg)*);
-                    let _ = f.flush();
-                } else {
-                    eprintln!($($arg)*);
-                }
-            }
-        }
-    }
+    let mut out_file = create_sink(&config);
 
     let interval = Duration::from_secs(config.interval_secs);
-
-    // Shell-wrapper child is spawned after warm-up so cloud IMDS probes (ureq may
-    // use helper threads) do not race with fork-heavy stressors under PID limits.
-    let mut child: Option<std::process::Child> = None;
 
     let mut cpu = CpuCollector::new(config.pid);
     let memory = MemoryCollector::new();
@@ -172,11 +178,17 @@ fn main() {
     let _ = cpu.collect();
     let _ = network.collect();
     let _ = disk.collect();
+
     std::thread::sleep(interval);
+
     // Non-blocking: on most non-cloud machines all probes fail fast
     // (EHOSTUNREACH); on cloud machines the matching probe returns in < 100 ms.
     // Either way the result is typically waiting by the time we reach here.
     let mut cloud_info: Option<CloudInfo> = cloud_rx.as_ref().and_then(|rx| rx.try_recv().ok());
+
+    // Shell-wrapper child is spawned after warm-up so cloud IMDS probes (ureq may
+    // use helper threads) do not race with fork-heavy stressors under PID limits.
+    let mut child: Option<std::process::Child> = None;
 
     // -----------------------------------------------------------------------
     // Shell-wrapper mode: spawn the tracked command after warm-up / cloud probe.
@@ -255,7 +267,7 @@ fn main() {
 
     // Emit CSV header once before the loop.
     if config.format == OutputFormat::Csv {
-        emit!("{}", output::csv::csv_header());
+        emit(&config, &mut out_file, output::csv::csv_header());
     }
 
     // Samples collected since the last S3 batch upload (for local fallback).
@@ -330,14 +342,15 @@ fn main() {
                 Ok(mut v) => {
                     v[format!("{}-version", env!("CARGO_PKG_NAME"))] =
                         serde_json::Value::String(env!("CARGO_PKG_VERSION").to_string());
-                    emit!("{}", v);
+                    emit(&config, &mut out_file, &v.to_string());
                 }
                 Err(e) => eprintln!("warn: json serialize error: {e}"),
             },
             OutputFormat::Csv => {
-                emit!(
-                    "{}",
-                    output::csv::sample_to_csv_row(&sample, config.interval_secs)
+                emit(
+                    &config,
+                    &mut out_file,
+                    &output::csv::sample_to_csv_row(&sample, config.interval_secs),
                 );
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::pedantic)]
 #![doc = include_str!("../README.md")]
 
 #[cfg(not(target_os = "linux"))]
@@ -14,6 +15,8 @@ mod thread_util;
 
 extern crate libc;
 
+use std::io::{Write, BufWriter};
+use std::fs::File;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -103,7 +106,7 @@ impl ResourceTracker {
     fn new() -> Self {
 
         let config = Config::load();
-        let out_file = create_sink(&config);
+        let out_file = Self::create_sink(&config);
         let interval = Duration::from_secs(config.interval_secs);
 
         let cpu = CpuCollector::new(config.pid);
@@ -233,11 +236,11 @@ impl ResourceTracker {
     fn emit_csv_header(&mut self) {
 
         if self.config.format == OutputFormat::Csv {
-            emit_metric_line(&self.config, &mut self.out_file, output::csv::csv_header());
+            Self::emit_metric_line(&self.config, &mut self.out_file, output::csv::csv_header());
         }
     }
 
-    fn renice_self(&self) {
+    fn renice_tracker(&self) {
 
         let Some(renice) = self.config.renice else {
             return;
@@ -303,6 +306,7 @@ impl ResourceTracker {
         sample.cpu.process_gpu_utilized = gpu_utilized;
 
         self.prev_loop_start = Some(loop_start);
+
         sample
     }
 
@@ -314,7 +318,7 @@ impl ResourceTracker {
                 Ok(mut v) => {
                     v[format!("{}-version", env!("CARGO_PKG_NAME"))] =
                         serde_json::Value::String(env!("CARGO_PKG_VERSION").to_string());
-                    emit_metric_line(
+                    Self::emit_metric_line(
                         &self.config,
                         &mut self.out_file,
                         &v.to_string(),
@@ -324,7 +328,7 @@ impl ResourceTracker {
             },
 
             OutputFormat::Csv => {
-                emit_metric_line(
+                Self::emit_metric_line(
                     &self.config,
                     &mut self.out_file,
                     &output::csv::sample_to_csv_row(sample, self.config.interval_secs),
@@ -379,7 +383,7 @@ impl ResourceTracker {
         let upload_handle = self.upload_handle.take();
         let remaining = std::mem::take(&mut self.unflushed);
 
-        shutdown(
+        Self::graceful_shutdown(
             exit_code,
             sentinel.as_ref(),
             run_ctx,
@@ -394,10 +398,11 @@ impl ResourceTracker {
 
         self.warmup_collectors();
         std::thread::sleep(self.interval);
+
         self.spawn_tracked_command();
         self.setup_sentinel();
         self.emit_csv_header();
-        self.renice_self();
+        self.renice_tracker();
 
         // Main sampling loop
         loop {
@@ -411,7 +416,6 @@ impl ResourceTracker {
             if let Some(code) = self.check_child_exit() {
                 self.shutdown(code);
             }
-
             if self.check_signal() {
                 self.shutdown(0);
             }
@@ -419,104 +423,103 @@ impl ResourceTracker {
             self.sleep_until_next_interval(loop_start);
         }
     }
-}
 
-// -----------------------------------------------------------------------
-// Output sink: stdout (default), file (--output), or suppressed (--quiet).
-// Warnings and errors always go to stderr via eprintln! regardless.
-// -----------------------------------------------------------------------
-//
-fn create_sink(config: &Config) -> Option<BufWriter<File>> {
 
-    if config.quiet {
-        return None;
-    }
+    // -----------------------------------------------------------------------
+    // Output sink: stdout (default), file (--output), or suppressed (--quiet).
+    // Warnings and errors always go to stderr via eprintln! regardless.
+    // -----------------------------------------------------------------------
+    //
+    fn create_sink(config: &Config) -> Option<BufWriter<File>> {
 
-    match config.output_file.as_deref() {
-        Some(path) => File::create(path).map(BufWriter::new).ok(),
-        None => None,
-    }
-}
+        if config.quiet {
+            return None;
+        }
 
-// ---------------------------------------------------------------------------
-// Graceful shutdown
-// ---------------------------------------------------------------------------
-//
-// Flush remaining samples, close the Sentinel run, then exit.
-//
-// Called on both shell-wrapper child exit and SIGTERM.  Replaces the former
-// bare `std::process::exit()` calls so the upload thread always gets a chance
-// to flush.
-//
-fn shutdown(
-    exit_code: i32,
-    sentinel: Option<&SentinelClient>,
-    run_ctx: Option<Arc<Mutex<RunContext>>>,
-    shutdown_flag: Option<Arc<AtomicBool>>,
-    upload_handle: Option<std::thread::JoinHandle<Vec<String>>>,
-    remaining: Vec<Sample>,
-    interval_secs: u64,
-) -> ! {
-
-    if let (Some(client), Some(ctx_arc), Some(flag), Some(handle)) =
-        (sentinel, run_ctx, shutdown_flag, upload_handle)
-    {
-        // Signal the upload thread to flush its buffer to S3, then wait for it.
-        // The thread performs one final S3 upload of any remaining buffered samples
-        // before it exits, and returns the list of all successfully uploaded URIs.
-        flag.store(true, Ordering::Relaxed);
-        let uploaded_uris = handle.join().unwrap_or_default();
-
-        // Route selection:
-        //   S3 route   -- at least one batch was uploaded; uploaded_uris is non-empty.
-        //                 The final flush is already included in uploaded_uris.
-        //   Inline route -- no S3 uploads (short run or all S3 failures); send all
-        //                   collected samples as a raw CSV string.
-        let remaining_csv = if uploaded_uris.is_empty() && !remaining.is_empty() {
-            Some(samples_to_csv(&remaining, interval_secs))
-        } else {
-            None
-        };
-
-        let ctx = ctx_arc.lock().unwrap_or_else(|e| e.into_inner());
-        if let Err(e) = close_run(
-            &client.agent,
-            &client.api_base,
-            &client.token,
-            &ctx,
-            Some(exit_code),
-            remaining_csv,
-            &uploaded_uris,
-        ) {
-            eprintln!("warn: sentinel close_run failed: {e}");
+        match config.output_file.as_deref() {
+            Some(path) => File::create(path).map(BufWriter::new).ok(),
+            None => None,
         }
     }
 
-    std::process::exit(exit_code);
-}
+    // ---------------------------------------------------------------------------
+    // Graceful shutdown
+    // ---------------------------------------------------------------------------
+    //
+    // Flush remaining samples, close the Sentinel run, then exit.
+    //
+    // Called on both shell-wrapper child exit and SIGTERM.  Replaces the former
+    // bare `std::process::exit()` calls so the upload thread always gets a chance
+    // to flush.
+    //
+    fn graceful_shutdown(
+        exit_code: i32,
+        sentinel: Option<&SentinelClient>,
+        run_ctx: Option<Arc<Mutex<RunContext>>>,
+        shutdown_flag: Option<Arc<AtomicBool>>,
+        upload_handle: Option<std::thread::JoinHandle<Vec<String>>>,
+        remaining: Vec<Sample>,
+        interval_secs: u64,
+    ) -> ! {
 
-// Emit one line of metric output to the selected sink.
-// quiet=true  -> no-op
-// output_file -> write to file and flush (so `tail -f` works)
-// default     -> eprintln! to stderr (keeps stdout clean for the tracked app)
-//
-use std::io::{Write, BufWriter};
-use std::fs::File;
+        if let (Some(client), Some(ctx_arc), Some(flag), Some(handle)) =
+            (sentinel, run_ctx, shutdown_flag, upload_handle)
+        {
+            // Signal the upload thread to flush its buffer to S3, then wait for it.
+            // The thread performs one final S3 upload of any remaining buffered samples
+            // before it exits, and returns the list of all successfully uploaded URIs.
+            flag.store(true, Ordering::Relaxed);
+            let uploaded_uris = handle.join().unwrap_or_default();
 
-fn emit_metric_line(config: &Config, out_file: &mut Option<BufWriter<File>>, msg: &str) {
+            // Route selection:
+            //   S3 route   -- at least one batch was uploaded; uploaded_uris is non-empty.
+            //                 The final flush is already included in uploaded_uris.
+            //   Inline route -- no S3 uploads (short run or all S3 failures); send all
+            //                   collected samples as a raw CSV string.
+            let remaining_csv = if uploaded_uris.is_empty() && !remaining.is_empty() {
+                Some(samples_to_csv(&remaining, interval_secs))
+            } else {
+                None
+            };
 
-    if config.quiet {
-        return;
-    }
-
-    match out_file {
-        Some(writer) => {
-            let _ = writeln!(writer, "{msg}");
-            let _ = writer.flush();
+            let ctx = ctx_arc.lock().unwrap_or_else(|e| e.into_inner());
+            if let Err(e) = close_run(
+                &client.agent,
+                &client.api_base,
+                &client.token,
+                &ctx,
+                Some(exit_code),
+                remaining_csv,
+                &uploaded_uris,
+            ) {
+                eprintln!("warn: sentinel close_run failed: {e}");
+            }
         }
-        None => eprintln!("{msg}"),
+
+        std::process::exit(exit_code);
+    }
+
+    // Emit one line of metric output to the selected sink.
+    // quiet=true  -> no-op
+    // output_file -> write to file and flush (so `tail -f` works)
+    // default     -> eprintln! to stderr (keeps stdout clean for the tracked app)
+    //
+    fn emit_metric_line(config: &Config, out_file: &mut Option<BufWriter<File>>, msg: &str) {
+
+        if config.quiet {
+            return;
+        }
+
+        match out_file {
+            Some(writer) => {
+                let _ = writeln!(writer, "{msg}");
+                let _ = writer.flush();
+            }
+            None => eprintln!("{msg}"),
+        }
     }
 }
+
 // ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**Renice**

The tracker can now adjust its own priority (`nice` level) to ensure maximum CPU resources remain allocated to the traced process.

Related ticket: [#28](https://github.com/SpareCores/resource-tracker-rs/issues/28)

**Refactoring**

The main change here is breaking up the long `main()` function
so the high-level logic is easier to follow.

*See Changelog for details.*

**`justfile` minor improvement**

Honour `CARGO_TARGET_DIR` if set, else fallback to `./target`.

Mapping VM source directories from the host can slow down builds. This can be fixed by placing the target directory outside the mapped drive using the `CARGO_TARGET_DIR` environment variable.